### PR TITLE
mSplashDialog should init again in show function

### DIFF
--- a/android/src/main/java/com/mehcode/reactnative/splashscreen/SplashScreen.java
+++ b/android/src/main/java/com/mehcode/reactnative/splashscreen/SplashScreen.java
@@ -23,11 +23,9 @@ public class SplashScreen {
             @Override
             public void run() {
                 if (!activity.isFinishing()) {
-                    if (mSplashDialog == null) {
-                        mSplashDialog = new Dialog(activity, R.style.RNSplashScreen_SplashTheme);
-                        mSplashDialog.setCancelable(false);
-                    }
-
+                    mSplashDialog = new Dialog(activity, R.style.RNSplashScreen_SplashTheme);
+                    mSplashDialog.setCancelable(false);
+                    
                     if (!mSplashDialog.isShowing()) {
                         mSplashDialog.show();
                     }


### PR DESCRIPTION
when press back key to exit app and enter it immediately, it will crash, beacause the dialog does not belong to the activity now, so it needs to init mSplashDialog again in show function