### PR TITLE
Add React dependency to podspec to fix build error

### DIFF
--- a/rn-splash-screen.podspec
+++ b/rn-splash-screen.podspec
@@ -14,4 +14,6 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "8.0"
   s.preserve_paths      = 'README.md', 'package.json', '*.js'
   s.source_files        = 'ios/RCTSplashScreen/**/*.{h,m}'
+
+  s.dependency          "React"
 end


### PR DESCRIPTION
Hi,

I got the following build error using CocoaPods 1.5.3:
`fatal error: 'React/RCTBridgeModule.h' file not found`

Adding `React` as an explicit dependency fixes it.

I've submitted this fix to other RN third party modules like https://github.com/react-community/react-native-languages/pull/5/files